### PR TITLE
Add domain management script

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,23 @@ The script will prompt you for:
 The script will automatically configure SSL using Let's Encrypt for the provided domain.
 
 Ensure that your domain DNS is correctly set up to point to the server's IP address. Certbot will handle the SSL setup and configure Nginx to use the certificates.
+
+## Adding Additional Domains
+
+If you need to point extra domains to an existing application, use the `manage_domains.sh` script included in this repository.
+
+### Step 1: Copy the Script
+
+```bash
+wget https://raw.githubusercontent.com/theafolayan/setup-laravel/main/manage_domains.sh
+chmod +x manage_domains.sh
+```
+
+### Step 2: Run the Script
+
+```bash
+sudo ./manage_domains.sh
+```
+
+The script lists applications found in `/var/www` and lets you choose which one to update. After selecting an app, provide the primary domain and any additional domains you want to add. The script updates the Nginx configuration and obtains SSL certificates for the new domains using Certbot.
+Make sure DNS A records for the new domain(s) point to your server before running the script. You'll be prompted to type `yes` to confirm the records are in place before the script requests SSL certificates.

--- a/manage_domains.sh
+++ b/manage_domains.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root."
+    exit 1
+fi
+
+# List available applications
+if [[ ! -d /var/www ]]; then
+    echo "/var/www does not exist."
+    exit 1
+fi
+
+mapfile -t APPS < <(find /var/www -mindepth 1 -maxdepth 1 -type d -printf "%f\n")
+if [[ ${#APPS[@]} -eq 0 ]]; then
+    echo "No applications found in /var/www."
+    exit 1
+fi
+
+echo "Select the application to manage:"
+select APP_NAME in "${APPS[@]}"; do
+    [[ -n "$APP_NAME" ]] && break
+    echo "Invalid selection."
+done
+
+read -rp "Enter the primary domain configured for $APP_NAME: " PRIMARY_DOMAIN
+NGINX_CONF="/etc/nginx/sites-available/${PRIMARY_DOMAIN}"
+if [[ ! -f "$NGINX_CONF" ]]; then
+    echo "Nginx config $NGINX_CONF not found."
+    exit 1
+fi
+
+read -rp "Enter additional domain(s) to add (space-separated): " NEW_DOMAINS
+
+DOMAIN_ARGS=("$PRIMARY_DOMAIN" "www.$PRIMARY_DOMAIN")
+NEW_ENTRIES=""
+for d in $NEW_DOMAINS; do
+    DOMAIN_ARGS+=("$d" "www.$d")
+    NEW_ENTRIES+=" $d www.$d"
+done
+
+# Update server_name line
+sed -i "/server_name/s/;/${NEW_ENTRIES};/" "$NGINX_CONF"
+
+nginx -t && systemctl reload nginx
+
+# Confirm DNS has been updated before requesting certificates
+echo "Ensure the following domains point to this server: $NEW_DOMAINS"
+read -rp "Type 'yes' once DNS records have propagated: " CONFIRM
+if [[ $CONFIRM != "yes" ]]; then
+    echo "Aborting SSL certificate request."
+    exit 1
+fi
+
+# Request certificates for all domains
+CERTBOT_ARGS=()
+for d in "${DOMAIN_ARGS[@]}"; do
+    CERTBOT_ARGS+=(-d "$d")
+done
+certbot --nginx --non-interactive --agree-tos -m "admin@${PRIMARY_DOMAIN}" "${CERTBOT_ARGS[@]}"
+
+echo "Added domains: $NEW_DOMAINS to $PRIMARY_DOMAIN"


### PR DESCRIPTION
## Summary
- add `manage_domains.sh` for adding extra domains and SSL certs
- document how to use the new script in README
- require explicit `yes` confirmation before requesting SSL certificates

## Testing
- `shellcheck manage_domains.sh`
- `shellcheck setup_laravel_nginx_ssl.sh >/tmp/shellcheck_setup.log && tail -n 20 /tmp/shellcheck_setup.log`


------
https://chatgpt.com/codex/tasks/task_e_68a226d3dcd4832b95265728ed9032c4