### PR TITLE
Include existing domains when renewing certificates

### DIFF
--- a/manage_domains.sh
+++ b/manage_domains.sh
@@ -55,6 +55,9 @@ if [[ ${#NEW_DOMAIN_ARR[@]} -eq 0 ]]; then
 fi
 
 DOMAIN_ARGS=("$PRIMARY_DOMAIN" "www.$PRIMARY_DOMAIN")
+for d in "${EXISTING_DOMAINS[@]}"; do
+    DOMAIN_ARGS+=("$d" "www.$d")
+done
 NEW_ENTRIES=""
 for d in "${NEW_DOMAIN_ARR[@]}"; do
     DOMAIN_ARGS+=("$d" "www.$d")


### PR DESCRIPTION
## Summary
- Include existing domains in certbot requests so earlier domains remain valid

## Testing
- `bash -n manage_domains.sh`
- `shellcheck manage_domains.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a8721d91bc832bbf5d26877dae56e4