### PR TITLE
Enable non-interactive Laravel setup with flags and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Before running this script, ensure that:
 ## Features
 
 - Installs Nginx, PHP (version selectable) with recommended OPcache configuration, MySQL or PostgreSQL, optional Memcached, and Composer.
-- Prompts for app name, domain, repository URL, database credentials, and whether to run a full system upgrade.
+- Supports interactive prompts or a fully non-interactive mode using command line flags.
 - After the domain is entered, displays the server IP and waits for confirmation that DNS A records for the domain and www subdomain point to it.
 - Generates secure random database passwords and secures MySQL without interactive prompts.
 - Clones a Laravel project from a specified GitHub repository, installs dependencies with `--no-dev --optimize-autoloader`, and caches configuration, routes, and views for better performance.
@@ -36,18 +36,58 @@ Make the script executable:
 chmod +x setup_laravel_nginx_ssl.sh
 ```
 ## Step 3: Run the Script
-Run the script with superuser privileges to start the installation process:
+Run the script with superuser privileges. The script defaults to PHP 8.4 and can run interactively or non-interactively.
+
+Interactive:
 
 ```bash
 sudo ./setup_laravel_nginx_ssl.sh
 ```
-The script will prompt you for:
 
-- Application name and domain.
-- Confirmation that DNS A records for the domain and www subdomain point to the server IP.
-- Laravel repository URL.
-- Which database to install (MySQL, PostgreSQL, or none) and the database name, username, and password.
-- Whether to run a full system upgrade and whether to install Memcached for caching.
+Non-interactive example:
+
+```bash
+sudo ./setup_laravel_nginx_ssl.sh -n \
+  -a myapp -d example.com --dns-confirm yes \
+  --repo-url https://github.com/laravel/laravel.git \
+  --db-choice mysql --db-name appdb --db-user appuser --db-pass secret
+```
+The script will prompt only for values not supplied via flags when running interactively.
+
+### Help and Flags
+
+View all available options:
+
+```bash
+./setup_laravel_nginx_ssl.sh --help
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-a`, `--app-name` | Application name | `laravel_app` |
+| `-d`, `--domain` | Domain name for the site | `example.com` |
+| `--dns-confirm` | Confirm DNS records are in place (`yes`/`no`) | `yes` |
+| `--repo-url` | Git repository containing the Laravel project | `https://github.com/laravel/laravel.git` |
+| `--db-choice` | Database to install (`mysql`, `postgresql`, or `none`) | `mysql` |
+| `--db-name` | Database name | `laravel_db` |
+| `--db-user` | Database user | `laravel_user` |
+| `--db-pass` | Database password | random |
+| `--php-version` | PHP version | `8.4` |
+| `-n`, `--non-interactive` | Skip prompts and use provided flags | _disabled_ |
+| `--dry-run` | Show commands without executing them | _disabled_ |
+| `-h`, `--help` | Display help information | _disabled_ |
+
+Example one-liner including all major flags:
+
+```bash
+sudo ./setup_laravel_nginx_ssl.sh -n \
+  -a myapp -d example.com --dns-confirm yes \
+  --repo-url https://github.com/laravel/laravel.git \
+  --db-choice mysql --db-name appdb --db-user appuser --db-pass secret \
+  --php-version 8.4 --dry-run
+```
+
+The `--dry-run` flag prints the commands that would run, letting you verify your settings without making any system changes.
 
 ## Step 4: SSL Setup
 The script will automatically configure SSL using Let's Encrypt for the provided domain.


### PR DESCRIPTION
## Summary
- add command-line flags, help output, and dry-run mode to setup script
- default to PHP 8.4 and allow skipping prompts in non-interactive runs
- document new usage patterns with an example one-liner
- add detailed README section describing available flags and dry-run

## Testing
- `bash -n setup_laravel_nginx_ssl.sh`
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck setup_laravel_nginx_ssl.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a976076b1c832ba3e9ee06a9e8bdc8