### PR TITLE
Fix boost_performance nginx tuning regex delimiters

### DIFF
--- a/boost_performance.sh
+++ b/boost_performance.sh
@@ -219,8 +219,8 @@ apply_nginx_tuning() {
 my $wc = $ENV{"WORKER_CONNECTIONS"};
 s/events\s*\{(.*?)\}/do {
     my $body = $1;
-    $body =~ s/^[\t ]*worker_connections\s+.*?;\s*\n?//mg;
-    $body =~ s/^[\t ]*multi_accept\s+.*?;\s*\n?//mg;
+    $body =~ s{^[\t ]*worker_connections\s+.*?;\s*\n?}{}mg;
+    $body =~ s{^[\t ]*multi_accept\s+.*?;\s*\n?}{}mg;
     $body =~ s/^\n+//;
     "events {\n    worker_connections ${wc};\n    multi_accept on;\n${body}}\n";
 }/egs;


### PR DESCRIPTION
## Summary
- update nginx events block rewrite in `boost_performance.sh` to use brace regex delimiters and avoid Perl syntax errors

## Testing
- ⚠️ `shellcheck boost_performance.sh` (command not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694170c5303c832b905b536432efc698)